### PR TITLE
Upgrade Compiler and Motoko Base to latest builds

### DIFF
--- a/package-set.dhall
+++ b/package-set.dhall
@@ -1,4 +1,3 @@
 let upstream =
-      https://github.com/kritzcreek/vessel-package-set/releases/download/mo-0.5.7-20210211/package-set.dhall sha256:43565631bf6b43639fcd0cae5cbb6b5d4f9bf5139e66ef600b8f7ded31821325
-
+      https://github.com/dfinity/vessel-package-set/releases/download/mo-0.8.4-20230311/package-set.dhall sha256:bf5cec8ba99cfa6abcdb793a4aeaea9f4c913a4bd97af0a556bd6e81aaf75cd4
 in  upstream

--- a/test/Test.mo
+++ b/test/Test.mo
@@ -7,48 +7,66 @@ import Suite "../src/Suite";
 
 let equals10 = Matchers.equals(T.nat(10));
 let equals20 = Matchers.equals(T.nat(20));
-let greaterThan10: Matchers.Matcher<Nat> = Matchers.greaterThan(10);
-let greaterThan20: Matchers.Matcher<Nat> = Matchers.greaterThan(20);
+let greaterThan10 : Matchers.Matcher<Nat> = Matchers.greaterThan(10);
+let greaterThan20 : Matchers.Matcher<Nat> = Matchers.greaterThan(20);
 let map : HM.HashMap<Text, Nat> = HM.HashMap<Text, Nat>(5, Text.equal, Text.hash);
 map.put("key1", 20);
 map.put("key2", 10);
 
-let suite = Suite.suite("Testing the testing", [
-    Suite.suite("equality", [
-        Suite.test("nats1", 10, equals10),
-        Suite.test("nats2", 20, equals10),
-        Suite.test("Chars", 'a', Matchers.equals(T.char('b'))),
-    ]),
-    Suite.testLazy("Lazy test execution", func(): Nat = 20, equals10),
-    Suite.test("Described as", 20, Matchers.describedAs("20's a lot mate.", equals10)),
-    Suite.suite("Combining matchers", [
-        Suite.test("anything", 10, Matchers.anything<Nat>()),
+let suite = Suite.suite(
+    "Testing the testing",
+    [
+        Suite.suite(
+            "equality",
+            [
+                Suite.test("nats1", 10, equals10),
+                Suite.test("nats2", 20, equals10),
+                Suite.test("Chars", 'a', Matchers.equals(T.char('b'))),
+            ],
+        ),
+        Suite.testLazy("Lazy test execution", func() : Nat = 20, equals10),
+        Suite.test("Described as", 20, Matchers.describedAs("20's a lot mate.", equals10)),
+        Suite.suite(
+            "Combining matchers",
+            [
+                Suite.test("anything", 10, Matchers.anything<Nat>()),
 
-        Suite.test("anyOf1", 20, Matchers.anyOf([equals10, equals20])),
-        Suite.test("anyOf2", 15, Matchers.anyOf([equals10, equals20])),
+                Suite.test("anyOf1", 20, Matchers.anyOf([equals10, equals20])),
+                Suite.test("anyOf2", 15, Matchers.anyOf([equals10, equals20])),
 
-        Suite.test("allOf1", 30, Matchers.allOf([greaterThan10, greaterThan20])),
-        Suite.test("allOf2", 15, Matchers.allOf([greaterThan10, greaterThan20])),
-        Suite.test("allOf2", 8, Matchers.allOf([greaterThan10, greaterThan20])),
-    ]),
+                Suite.test("allOf1", 30, Matchers.allOf([greaterThan10, greaterThan20])),
+                Suite.test("allOf2", 15, Matchers.allOf([greaterThan10, greaterThan20])),
+                Suite.test("allOf2", 8, Matchers.allOf([greaterThan10, greaterThan20])),
+            ],
+        ),
 
-    Suite.suite("Comparing numbers", [
-        Suite.test("greaterThan1", 20, greaterThan10),
-        Suite.test("greaterThan2", 5, greaterThan10),
-    ]),
-    Suite.suite("Array matchers", [
-        Suite.test("Should match", [10, 20], Matchers.array([equals10, equals20])),
-        Suite.test("Should fail", [20, 10], Matchers.array([equals10, equals20])),
-        Suite.test("Length mismatch", ([] : [Nat]), Matchers.array([equals10, equals20])),
-    ]),
+        Suite.suite(
+            "Comparing numbers",
+            [
+                Suite.test("greaterThan1", 20, greaterThan10),
+                Suite.test("greaterThan2", 5, greaterThan10),
+            ],
+        ),
+        Suite.suite(
+            "Array matchers",
+            [
+                Suite.test("Should match", [10, 20], Matchers.array([equals10, equals20])),
+                Suite.test("Should fail", [20, 10], Matchers.array([equals10, equals20])),
+                Suite.test("Length mismatch", ([] : [Nat]), Matchers.array([equals10, equals20])),
+            ],
+        ),
 
-    Suite.suite("Hashmap matchers", [
-        Suite.test("Should have key", map, HMMatchers.hasKey<Text, Nat>(T.text("key1"))),
-        Suite.test("Should fail with missing key", map, HMMatchers.hasKey<Text, Nat>(T.text("unknown"))),
-        Suite.test("Should match at key", map, HMMatchers.atKey(T.text("key1"), equals20)),
-        Suite.test("should fail at key", map, HMMatchers.atKey(T.text("key2"), equals20)),
-        Suite.test("Should fail with missing key2", map, HMMatchers.atKey(T.text("unknown"), equals20)),
-    ])    
-]);
+        Suite.suite(
+            "Hashmap matchers",
+            [
+                Suite.test("Should have key", map, HMMatchers.hasKey<Text, Nat>(T.text("key1"))),
+                Suite.test("Should fail with missing key", map, HMMatchers.hasKey<Text, Nat>(T.text("unknown"))),
+                Suite.test("Should match at key", map, HMMatchers.atKey<Text, Nat>(T.text("key1"), equals20)),
+                Suite.test("should fail at key", map, HMMatchers.atKey<Text, Nat>(T.text("key2"), equals20)),
+                Suite.test("Should fail with missing key2", map, HMMatchers.atKey<Text, Nat>(T.text("unknown"), equals20)),
+            ],
+        ),
+    ],
+);
 
-Suite.run(suite)
+Suite.run(suite);

--- a/test/Test.mo
+++ b/test/Test.mo
@@ -7,66 +7,48 @@ import Suite "../src/Suite";
 
 let equals10 = Matchers.equals(T.nat(10));
 let equals20 = Matchers.equals(T.nat(20));
-let greaterThan10 : Matchers.Matcher<Nat> = Matchers.greaterThan(10);
-let greaterThan20 : Matchers.Matcher<Nat> = Matchers.greaterThan(20);
+let greaterThan10: Matchers.Matcher<Nat> = Matchers.greaterThan(10);
+let greaterThan20: Matchers.Matcher<Nat> = Matchers.greaterThan(20);
 let map : HM.HashMap<Text, Nat> = HM.HashMap<Text, Nat>(5, Text.equal, Text.hash);
 map.put("key1", 20);
 map.put("key2", 10);
 
-let suite = Suite.suite(
-    "Testing the testing",
-    [
-        Suite.suite(
-            "equality",
-            [
-                Suite.test("nats1", 10, equals10),
-                Suite.test("nats2", 20, equals10),
-                Suite.test("Chars", 'a', Matchers.equals(T.char('b'))),
-            ],
-        ),
-        Suite.testLazy("Lazy test execution", func() : Nat = 20, equals10),
-        Suite.test("Described as", 20, Matchers.describedAs("20's a lot mate.", equals10)),
-        Suite.suite(
-            "Combining matchers",
-            [
-                Suite.test("anything", 10, Matchers.anything<Nat>()),
+let suite = Suite.suite("Testing the testing", [
+    Suite.suite("equality", [
+        Suite.test("nats1", 10, equals10),
+        Suite.test("nats2", 20, equals10),
+        Suite.test("Chars", 'a', Matchers.equals(T.char('b'))),
+    ]),
+    Suite.testLazy("Lazy test execution", func(): Nat = 20, equals10),
+    Suite.test("Described as", 20, Matchers.describedAs("20's a lot mate.", equals10)),
+    Suite.suite("Combining matchers", [
+        Suite.test("anything", 10, Matchers.anything<Nat>()),
 
-                Suite.test("anyOf1", 20, Matchers.anyOf([equals10, equals20])),
-                Suite.test("anyOf2", 15, Matchers.anyOf([equals10, equals20])),
+        Suite.test("anyOf1", 20, Matchers.anyOf([equals10, equals20])),
+        Suite.test("anyOf2", 15, Matchers.anyOf([equals10, equals20])),
 
-                Suite.test("allOf1", 30, Matchers.allOf([greaterThan10, greaterThan20])),
-                Suite.test("allOf2", 15, Matchers.allOf([greaterThan10, greaterThan20])),
-                Suite.test("allOf2", 8, Matchers.allOf([greaterThan10, greaterThan20])),
-            ],
-        ),
+        Suite.test("allOf1", 30, Matchers.allOf([greaterThan10, greaterThan20])),
+        Suite.test("allOf2", 15, Matchers.allOf([greaterThan10, greaterThan20])),
+        Suite.test("allOf2", 8, Matchers.allOf([greaterThan10, greaterThan20])),
+    ]),
 
-        Suite.suite(
-            "Comparing numbers",
-            [
-                Suite.test("greaterThan1", 20, greaterThan10),
-                Suite.test("greaterThan2", 5, greaterThan10),
-            ],
-        ),
-        Suite.suite(
-            "Array matchers",
-            [
-                Suite.test("Should match", [10, 20], Matchers.array([equals10, equals20])),
-                Suite.test("Should fail", [20, 10], Matchers.array([equals10, equals20])),
-                Suite.test("Length mismatch", ([] : [Nat]), Matchers.array([equals10, equals20])),
-            ],
-        ),
+    Suite.suite("Comparing numbers", [
+        Suite.test("greaterThan1", 20, greaterThan10),
+        Suite.test("greaterThan2", 5, greaterThan10),
+    ]),
+    Suite.suite("Array matchers", [
+        Suite.test("Should match", [10, 20], Matchers.array([equals10, equals20])),
+        Suite.test("Should fail", [20, 10], Matchers.array([equals10, equals20])),
+        Suite.test("Length mismatch", ([] : [Nat]), Matchers.array([equals10, equals20])),
+    ]),
 
-        Suite.suite(
-            "Hashmap matchers",
-            [
-                Suite.test("Should have key", map, HMMatchers.hasKey<Text, Nat>(T.text("key1"))),
-                Suite.test("Should fail with missing key", map, HMMatchers.hasKey<Text, Nat>(T.text("unknown"))),
-                Suite.test("Should match at key", map, HMMatchers.atKey<Text, Nat>(T.text("key1"), equals20)),
-                Suite.test("should fail at key", map, HMMatchers.atKey<Text, Nat>(T.text("key2"), equals20)),
-                Suite.test("Should fail with missing key2", map, HMMatchers.atKey<Text, Nat>(T.text("unknown"), equals20)),
-            ],
-        ),
-    ],
-);
+    Suite.suite("Hashmap matchers", [
+        Suite.test("Should have key", map, HMMatchers.hasKey<Text, Nat>(T.text("key1"))),
+        Suite.test("Should fail with missing key", map, HMMatchers.hasKey<Text, Nat>(T.text("unknown"))),
+        Suite.test("Should match at key", map, HMMatchers.atKey<Text, Nat>(T.text("key1"), equals20)),
+        Suite.test("should fail at key", map, HMMatchers.atKey<Text, Nat>(T.text("key2"), equals20)),
+        Suite.test("Should fail with missing key2", map, HMMatchers.atKey<Text, Nat>(T.text("unknown"), equals20)),
+    ])    
+]);
 
-Suite.run(suite);
+Suite.run(suite)

--- a/test/package-set.dhall
+++ b/test/package-set.dhall
@@ -1,1 +1,0 @@
-../package-set.dhall

--- a/test/vessel.dhall
+++ b/test/vessel.dhall
@@ -1,1 +1,0 @@
-../vessel.dhall

--- a/vessel.dhall
+++ b/vessel.dhall
@@ -1,4 +1,1 @@
-{
-  dependencies = [ "base" ],
-  compiler = Some "0.5.8"
-}
+{ dependencies = [ "base" ], compiler = Some "0.8.5" }

--- a/vessel.dhall
+++ b/vessel.dhall
@@ -1,1 +1,4 @@
-{ dependencies = [ "base" ], compiler = Some "0.8.5" }
+{ 
+  dependencies = [ "base" ],
+  compiler = Some "0.8.5"
+}

--- a/vessel.dhall
+++ b/vessel.dhall
@@ -1,4 +1,4 @@
-{ 
+{
   dependencies = [ "base" ],
   compiler = Some "0.8.5"
 }


### PR DESCRIPTION
Have:
- upgraded vessel (compiler) to latest
- upgraded packages (motoko base) to latest
- removed no longer necessary .dhall files on /test folder
- fixed Test.mo, lines 64:65:
  - From: HMMatchers.atKey(...)
  - To: HMMatchers.atKey<Text, Nat>() (compiler now complains that it does not allow indirect types)

This is the current output of Test.mo:
![Screenshot 2023-03-21 at 11 59 45](https://user-images.githubusercontent.com/19423709/226644335-bd13287f-639c-4c9a-ba8e-0515b19e93d8.png)
![Screenshot 2023-03-21 at 11 59 54](https://user-images.githubusercontent.com/19423709/226644345-f1a4af43-6d99-4821-a1bf-716b9f577f14.png)

Since some tests are supposed to fail, I am afraid that some of them are real issues while others are not.

@kritzcreek can you please take a deeper look and see if this could be ready to release?